### PR TITLE
Update template.yaml with CONTROL_TOWER_HOME_REGION variable

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -111,6 +111,7 @@ Resources:
                     CONFIG_RECORDER_OVERRIDE_DAILY_RESOURCE_LIST: !Ref ConfigRecorderDailyResourceTypes
                     CONFIG_RECORDER_OVERRIDE_EXCLUDED_RESOURCE_LIST: !Ref ConfigRecorderExcludedResourceTypes
                     CONFIG_RECORDER_DEFAULT_RECORDING_FREQUENCY: !Ref ConfigRecorderDefaultRecordingFrequency
+                    CONTROL_TOWER_HOME_REGION: !Ref 'AWS::Region'
 
     ConsumerLambdaEventSourceMapping:
         Type: AWS::Lambda::EventSourceMapping


### PR DESCRIPTION
added the CONTROL_TOWER_HOME_REGION: !Ref 'AWS::Region' variable for setting the Global Resource recording in the Home region only with ct_configrecorder_override_consumer.py.