### PR TITLE
Update ct_configrecorder_override_consumer.py to only include globals in home region

### DIFF
--- a/ct_configrecorder_override_consumer.py
+++ b/ct_configrecorder_override_consumer.py
@@ -86,6 +86,9 @@ def lambda_handler(event, context):
         try:
             role_arn = 'arn:aws:iam::' + account_id + ':role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig'
 
+            ## added IAM global resource list
+            GLOBAL_IAM_RESOURCE_LIST = ['AWS::IAM::Group','AWS::IAM::Policy','AWS::IAM::Role','AWS::IAM::User']
+
             CONFIG_RECORDER_DAILY_RESOURCE_STRING = os.getenv('CONFIG_RECORDER_OVERRIDE_DAILY_RESOURCE_LIST')
             CONFIG_RECORDER_OVERRIDE_DAILY_RESOURCE_LIST = CONFIG_RECORDER_DAILY_RESOURCE_STRING.split(
                 ',') if CONFIG_RECORDER_DAILY_RESOURCE_STRING != '' else []
@@ -97,6 +100,18 @@ def lambda_handler(event, context):
             #remove any resource type from daily list that are in exclision list
             res = [x for x in CONFIG_RECORDER_OVERRIDE_DAILY_RESOURCE_LIST if x not in CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST]
             CONFIG_RECORDER_OVERRIDE_DAILY_RESOURCE_LIST[:] = res
+
+            ## create two new lists - NOT_HOME and HOME
+            CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST_NOT_HOME = []
+            CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST_HOME = []
+
+            ## remove any of the global IAM resources from exclusion list for HOME region
+            home = [x for x in CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST if x not in GLOBAL_IAM_RESOURCE_LIST]
+            CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST_HOME[:] = home
+            ## take home list and add globals for NOT_HOME exclusion list for linked regions
+            CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST_NOT_HOME = home + GLOBAL_IAM_RESOURCE_LIST
+
+            home_region = os.getenv('CONTROL_TOWER_HOME_REGION') == aws_region
 
             # Event = Delete is when stack is deleted, we rollback changed made and leave it as ControlTower Intended
             if event == 'Delete':
@@ -119,7 +134,8 @@ def lambda_handler(event, context):
                         'allSupported': False,
                         'includeGlobalResourceTypes': False,
                         'exclusionByResourceTypes': {
-                            'resourceTypes': CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST
+                        ## for exclusion list exclusionByResourceTypes.resourceTypes: if home_region==true use home, else use not_home
+                            'resourceTypes': CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST_HOME if home_region == True else CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST_NOT_HOME
                         },
                         'recordingStrategy': {
                             'useOnly': 'EXCLUSION_BY_RESOURCE_TYPES'


### PR DESCRIPTION
…resources in the Home region.

Adds a list and list comprehension to include the 4 global IAM resource-types in recording scope for the Control Tower Home region only using two additional new lists for the exclusions.

This is necessary since the 'exclusionByResourceTypes' option overrides the 'includeGlobalResourceTypes' option.